### PR TITLE
chore: remove deprecated plugin wrapper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "com.github.node-gradle.node" version "5.0.0"
-    id "run.halo.plugin.devtools" version "0.0.6"
+    id "run.halo.plugin.devtools" version "0.0.9"
     id "io.freefair.lombok" version "8.0.1"
     id 'java'
 }
@@ -17,7 +17,7 @@ repositories {
 
 dependencies {
 
-    implementation platform('run.halo.tools.platform:plugin:2.6.0-SNAPSHOT')
+    implementation platform('run.halo.tools.platform:plugin:2.10.0-SNAPSHOT')
     compileOnly 'run.halo.app:api'
 
     testImplementation 'run.halo.app:api'

--- a/src/main/java/run/halo/unsplash/UnsplashPlugin.java
+++ b/src/main/java/run/halo/unsplash/UnsplashPlugin.java
@@ -1,9 +1,9 @@
 package run.halo.unsplash;
 
-import org.pf4j.PluginWrapper;
 import org.springframework.stereotype.Component;
-import run.halo.app.extension.SchemeManager;
+
 import run.halo.app.plugin.BasePlugin;
+import run.halo.app.plugin.PluginContext;
 
 /**
  * @author ryanwang
@@ -12,15 +12,8 @@ import run.halo.app.plugin.BasePlugin;
 @Component
 public class UnsplashPlugin extends BasePlugin {
 
-    public UnsplashPlugin(PluginWrapper wrapper) {
-        super(wrapper);
+    public UnsplashPlugin(PluginContext context) {
+        super(context);
     }
 
-    @Override
-    public void start() {
-    }
-
-    @Override
-    public void stop() {
-    }
 }

--- a/src/main/resources/plugin.yaml
+++ b/src/main/resources/plugin.yaml
@@ -5,14 +5,16 @@ metadata:
 spec:
   enabled: true
   version: 1.0.0
-  requires: ">=2.0.0"
+  requires: ">=2.10.0"
   author:
-    name: Halo OSS Team
+    name: Halo
     website: https://github.com/halo-dev
   logo: logo.svg
   settingName: unsplash-settings
   configMapName: unsplash-settings
-  homepage: https://github.com/halo-sigs/plugin-unsplash
+  repo: https://github.com/halo-sigs/plugin-unsplash
+  homepage: https://www.halo.run/store/apps/app-NRcGw
+  issues: https://github.com/halo-sigs/plugin-unsplash/issues
   displayName: "Unsplash"
   description: "提供从 Unsplash 选择或转存图片的能力"
   license:


### PR DESCRIPTION
### What this PR does?
移除对已过时的 PluginWrapper 的引用

see also https://github.com/halo-dev/halo/pull/6243

```release-note
None
```